### PR TITLE
Add GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,10 @@
-name: Rust Build and Test
+name: Build and Test
 
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  release:
-    types: [ released ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,8 +20,4 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-    - name: Publish crate
-      if: ${{ env.GITHUB_EVENT_NAME == 'release' }}
-      run: cargo publish --token ${CRATES_TOKEN}
-      env:
-        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+on:
+  push:
+    tags: 
+    - 'v*'
+
+name: Create release
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish crate
+      run: cargo publish --token ${CRATES_TOKEN}
+      env:
+        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+    - name: Install cargo-deb
+      run: cargo install cargo-deb
+    - name: Create .deb
+      id: build_deb
+      run: |
+        output=$(cargo deb)
+        echo "::set-output name=asset_path::$output"
+        echo "::set-output name=asset_file::$(basename $output)"
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ${{ steps.build_deb.outputs.asset_path }}
+        asset_name: ${{ steps.build_deb.outputs.asset_file }}
+        asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        release_name: ${{ github.ref }}
         draft: false
         prerelease: false
     - name: Upload Release Asset

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust Build and Test
 
 on:
   push:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Publish crate
-      if: ${{ env.GITHUB_EVENT_TYPE == 'release' }}
+      if: ${{ env.GITHUB_EVENT_NAME == 'release' }}
       run: cargo publish --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [ released ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,3 +22,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Publish crate
+      if: ${{ env.GITHUB_EVENT_TYPE == "release" }}
+      run: cargo publish --token ${CRATES_TOKEN}
+      env:
+        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Publish crate
-      if: ${{ env.GITHUB_EVENT_TYPE == "release" }}
+      if: ${{ env.GITHUB_EVENT_TYPE == 'release' }}
       run: cargo publish --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rss_emailer"
 description = "Utility to check RSS feeds and email new posts to configured addresses."
 license = "Apache-2.0"
 authors = ["Kyle Buzby <kyle@buzby.dev>"]
-version = "0.1.1"
+version = "0.1.1.2"
 edition = "2021"
 readme = "./README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rss_emailer"
 description = "Utility to check RSS feeds and email new posts to configured addresses."
 license = "Apache-2.0"
 authors = ["Kyle Buzby <kyle@buzby.dev>"]
-version = "0.1.1.2"
+version = "0.1.2"
 edition = "2021"
 readme = "./README.md"
 


### PR DESCRIPTION
Closes #5 

# To Do
- [x] Create basic yml for build and test
- [x] Update naming to be more friendly
- [x] Publish releases

# Release handling
For release handling need to figure out how to decide when to publish a release version and how it should be done.
Currently it would require a version bump with every merge to main, but that would be less than ideal. Ideal would be if it could automatically increment in some fashion (maybe just with a build number) unless there's some additional override.